### PR TITLE
Dev

### DIFF
--- a/lua/slib_framework/core/base/sh_script_include.lua
+++ b/lua/slib_framework/core/base/sh_script_include.lua
@@ -69,33 +69,15 @@ function slib.usingDirectory(root_scripts_directory_path, loading_text, disable_
 	end
 
 	local inc = slib.CreateIncluder(nil, loading_text)
-
-	for i = #files_list, 1, -1 do
-		local fileData = files_list[i]
-		if fileData.file_type == 'sh' then
-			inc:using(root_scripts_directory_path .. '/' .. fileData.file_path, disable_auto_include)
-			table.remove(files_list, i)
-		end
-	end
-
-	for i = #files_list, 1, -1 do
-		local fileData = files_list[i]
-		if fileData.file_type == 'sv' then
-			inc:using(root_scripts_directory_path .. '/' .. fileData.file_path, disable_auto_include)
-			table.remove(files_list, i)
-		end
 	local return_values = {
 		['cl'] = {},
 		['sv'] = {},
 		['sh'] = {},
 	}
-	end
 
-	for i = #files_list, 1, -1 do
-		local fileData = files_list[i]
-		if fileData.file_type == 'cl' then
-			inc:using(root_scripts_directory_path .. '/' .. fileData.file_path, disable_auto_include)
-		end
+	for _, fileData in pairs(files_list) do
+		local return_value = inc:using(root_scripts_directory_path .. '/' .. fileData.file_path, disable_auto_include)
+		table.insert(return_values[fileData.file_type], return_value)
 	end
 
 	for _, directory_path in ipairs(directories) do

--- a/lua/slib_framework/core/base/sh_script_include.lua
+++ b/lua/slib_framework/core/base/sh_script_include.lua
@@ -81,6 +81,11 @@ function slib.usingDirectory(root_scripts_directory_path, loading_text, disable_
 	end
 
 	for _, directory_path in ipairs(directories) do
-		slib.usingDirectory(root_scripts_directory_path .. '/' .. directory_path, loading_text)
+		local sub_return_values = slib.usingDirectory(root_scripts_directory_path .. '/' .. directory_path, loading_text)
+		for key, table_value in pairs(sub_return_values) do
+			table.Add(return_values[key], table_value)
+		end
 	end
+
+	return return_values
 end

--- a/lua/slib_framework/core/base/sh_script_include.lua
+++ b/lua/slib_framework/core/base/sh_script_include.lua
@@ -84,6 +84,11 @@ function slib.usingDirectory(root_scripts_directory_path, loading_text, disable_
 			inc:using(root_scripts_directory_path .. '/' .. fileData.file_path, disable_auto_include)
 			table.remove(files_list, i)
 		end
+	local return_values = {
+		['cl'] = {},
+		['sv'] = {},
+		['sh'] = {},
+	}
 	end
 
 	for i = #files_list, 1, -1 do


### PR DESCRIPTION
including every file in one loop instead of separating into three by file types may affect the process in include order but it is thought the only difference will be messages on the terminal not being printed in order of file types but random 